### PR TITLE
Update HandTrackingSystem to support new syntax for new python server

### DIFF
--- a/Assets/HandTrackingAPI/Scripts/HandTrackingSystem.cs
+++ b/Assets/HandTrackingAPI/Scripts/HandTrackingSystem.cs
@@ -164,8 +164,11 @@ namespace HandTrackingModule
 
         private string GenerateTypeRequestCode()
         {
-            char[] code = new char[3];
-            int i = 0;
+            char[] code = new char[4];
+            int i = 1;
+
+            // the : is so that the python socket side can discriminate between this and messages from its socket sender
+            code[0] = ':';
             foreach (bool value in ReceiveTypes.Values)
             {
                 code[i] = value ? '1' : '0';


### PR DESCRIPTION
Just added the colon prefix so the python server knows this is a client not a sender